### PR TITLE
Remove double encode

### DIFF
--- a/lib/ory/hydra/helpers/body.ex
+++ b/lib/ory/hydra/helpers/body.ex
@@ -1,19 +1,18 @@
 defmodule ORY.Hydra.Helpers.Body do
   @spec encode!(ORY.Hydra.Operation.t(), ORY.Hydra.Config.t()) :: String.t() | no_return
-  def encode!(%{ method: :get }, _config) do
+  def encode!(%{method: :get}, _config) do
     ""
   end
 
-  def encode!(%{ content_type: :json } = operation, config) do
+  def encode!(%{content_type: :json} = operation, config) do
     operation.params
     |> Map.drop(operation.params_in_query)
     |> config.json_codec.encode!()
   end
 
-  def encode!(%{ content_type: :form_urlencoded } = operation, _config) do
+  def encode!(%{content_type: :form_urlencoded} = operation, _config) do
     operation.params
     |> Map.drop(operation.params_in_query)
     |> URI.encode_query()
-    |> URI.encode_www_form()
   end
 end


### PR DESCRIPTION
This PR resolves the issue that persists for `content_type: :form_urlencoded` where the body tag was not being passed.