### PR TITLE
update query params for consent session revocation

### DIFF
--- a/lib/ory/hydra.ex
+++ b/lib/ory/hydra.ex
@@ -319,7 +319,7 @@ defmodule ORY.Hydra do
     %Operation{
       method: :delete,
       params: params,
-      params_in_query: [:subject],
+      params_in_query: [:all, :client, :subject],
       path: "/oauth2/auth/sessions/consent"
     }
   end


### PR DESCRIPTION
Some parameters were missing from the `params_in_query` list for `revoke_consent_sessions`, see [docs](https://www.ory.sh/hydra/docs/reference/api/#revokes-consent-sessions-of-a-subject-for-a-specific-oauth-20-client).